### PR TITLE
Allow spaces in filenames passed to STOR command

### DIFF
--- a/lib/ftp/commands/stor.js
+++ b/lib/ftp/commands/stor.js
@@ -1,6 +1,17 @@
 import when from 'when';
 
 export default function (thisCmd, fileName) {
+  
+  if(arguments['2']) {
+    const keys = Object.keys(arguments);
+    keys.shift();
+    const nameParts = [];
+    for(let i = 0; i < keys.length; i++) {
+      nameParts.push(arguments[keys[i]]);
+    }
+    fileName = nameParts.join(' ');
+  }
+  
   if (!~['PORT', 'PASV'].indexOf(this.previousCommand)) {
     this.reply(503);
     return;


### PR DESCRIPTION
This will contact with spaces any filename sent via STOR command with a space.

Perhaps an improvement here would be to allow a "glue" parameter to contact with, rather than a hard-coded space.
